### PR TITLE
Add Memorial Day 2026 announcement to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,14 +39,14 @@ title: Welcome
       The Meeting will take place at the offices of Thompson, Dreessen & Dorner at 5:30pm.
       The address is 10836 Old Mill Rd, Omaha, NE 68154.
     </p>
-  </div>
-  <div class="notice">
-    <h1>Announcement:</h1>
-    <p>The American Legion's Memorial Day Service will be at 9:10am on Monday, May 26th. Please join us as we remember those who came before us and fought for our freedom. </p>
   </div> -->
 
-  <div class="spc notice clear" style="margin-top: 30px;>
+  <div class="notice">
+    <h1>Announcement:</h1>
+    <p>The American Legion's Memorial Day Service will be at 8:50am on Monday, May 25th. Please join us as we remember those who came before us and fought for our freedom. </p>
+  </div>
 
+  <div class="spc clear" style="margin-top: 30px;>
     <p class="OWH">
     	<img src="images/OWH.jpg" class="OWHpic"></img><br /><br />
     	<span class="bold">Michael Kelly</span>,


### PR DESCRIPTION
American Legion service at 8:50am on Monday, May 25th.

🤖 Generated with [Claude Code](https://claude.ai/code)